### PR TITLE
fix: enable SPA routing on Cloudflare Workers

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,6 +3,7 @@
   "name": "website",
   "compatibility_date": "2025-04-01",
   "assets": {
-    "directory": "./dist"
+    "directory": "./dist",
+    "not_found_handling": "single-page-application"
   }
 }


### PR DESCRIPTION
## Summary
- Adds `not_found_handling: single-page-application` to the `assets` config in `wrangler.jsonc`
- Fixes direct URL access to SPA routes (e.g. `/products/desktop`, `/downloads`) which were returning 404 on Cloudflare
- Navigation from the homepage already worked; this fix makes deep links work too

## Root cause
Cloudflare Workers serves static files from `dist/`. When a user visits a route directly, no matching file exists so Cloudflare returned a 404 instead of `index.html`. With `not_found_handling: single-page-application`, Cloudflare falls back to serving `index.html` and React Router handles the route client-side.

## Test plan
- [ ] Deploy to Cloudflare and visit `https://kaleidoswap.com/products/desktop` directly — should render the Desktop page
- [ ] Visit `https://kaleidoswap.com/downloads` directly — should render the Downloads page
- [ ] Confirm homepage and in-app navigation still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)