### PR TITLE
fix: make language switcher reachable in mobile menu

### DIFF
--- a/src/components/common/LanguageSwitcher.tsx
+++ b/src/components/common/LanguageSwitcher.tsx
@@ -24,6 +24,7 @@ export const LanguageSwitcher = ({ variant = 'default', dropdownPosition = 'abov
   const [isOpen, setIsOpen] = useState(false)
   const [focusedIndex, setFocusedIndex] = useState(-1)
   const dropdownRef = useRef<HTMLDivElement>(null)
+  const listboxRef = useRef<HTMLDivElement>(null)
   const buttonRefs = useRef<(HTMLButtonElement | null)[]>([])
 
   const currentLanguage = languages.find((lang) => lang.code === i18n.language) || languages[0]
@@ -93,6 +94,14 @@ export const LanguageSwitcher = ({ variant = 'default', dropdownPosition = 'abov
     }
   }, [focusedIndex])
 
+  // Bring the dropdown fully into view when it opens — inside the scrollable
+  // mobile menu it can otherwise render below the fold.
+  useEffect(() => {
+    if (isOpen) {
+      listboxRef.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+    }
+  }, [isOpen])
+
   return (
     <div ref={dropdownRef} className={cn('relative', className)}>
       <button
@@ -127,6 +136,7 @@ export const LanguageSwitcher = ({ variant = 'default', dropdownPosition = 'abov
 
       {isOpen && (
         <div
+          ref={listboxRef}
           className={cn(
             'absolute left-0 min-w-[160px] bg-gray-800 border border-gray-700 rounded-xl shadow-xl overflow-hidden z-50',
             dropdownPosition === 'above' ? 'bottom-full mb-2' : 'top-full mt-2'

--- a/src/components/nav/Navbar.tsx
+++ b/src/components/nav/Navbar.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
 
 // Saved page-scroll position while the mobile menu is open (iOS needs position:fixed on body)
 let _savedScrollY = 0
@@ -315,12 +316,13 @@ export const Navbar = () => {
             </button>
           </div>
 
-          {/* Mobile Navigation */}
-          {isOpen && (
+          {/* Mobile Navigation — portaled to body so `fixed` resolves against
+              the viewport, not a transformed ancestor (div.animate-fadeIn). */}
+          {isOpen && createPortal(
             <div
               ref={mobileMenuRef}
               id="mobile-menu"
-              className="md:hidden fixed inset-0 top-16 bg-gray-900/95 backdrop-blur-md z-40 overflow-y-auto overscroll-contain"
+              className="md:hidden fixed inset-x-0 top-16 h-[calc(100dvh-4rem)] bg-gray-900/95 backdrop-blur-md z-40 overflow-y-auto overscroll-contain"
               role="dialog"
               aria-modal="true"
               aria-label={t('Mobile navigation menu')}
@@ -422,7 +424,8 @@ export const Navbar = () => {
                   </Button>
                 </div>
               </div>
-            </div>
+            </div>,
+            document.body
           )}
         </div>
       </nav>


### PR DESCRIPTION
## Summary
On mobile, the language switcher could not be used: the full-screen nav menu (`position: fixed`) was trapped by `div.animate-fadeIn`, which keeps a `transform` after its intro animation and so becomes the containing block for `fixed` descendants. The menu was sized to the whole document (~8000px) instead of the viewport, could not scroll, and the language dropdown fell off-screen.

- **Navbar**: portal the mobile menu to `document.body` so `fixed` resolves against the viewport; add an explicit `h-[calc(100dvh-4rem)]`.
- **LanguageSwitcher**: scroll the dropdown into view when it opens.

## Test plan
- [x] Mobile viewport (375×812): menu opens at top:64, height = viewport − navbar, scrolls correctly
- [x] Language dropdown opens fully on-screen; all 7 languages selectable; switching works
- [ ] Desktop nav unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)