### PR TITLE
feat: overhaul Products page and Hero CTA links

### DIFF
--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -1,4 +1,4 @@
-import { Check, Download, Hammer, Monitor } from 'lucide-react'
+import { Check, Download, Hammer } from 'lucide-react'
 import { Helmet } from 'react-helmet-async'
 import { Button } from '@/components/common/Button'
 import { KaleidoScopeHeroAnimation } from '@/components/animations/KaleidoScopeHeroAnimation'

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -63,7 +63,7 @@ export const HeroSection = () => {
             <div className="flex flex-col sm:flex-row gap-4">
               <Button
                 size="lg"
-                onClick={() => handleNavigation('https://docs.kaleidoswap.com/sdk/introduction', true)}
+                onClick={() => handleNavigation('/products/sdk', false)}
                 className="h-12 px-8 btn-glow flex items-center justify-center gap-2 w-full sm:w-auto"
               >
                 <Hammer className="w-5 h-5" />
@@ -75,8 +75,8 @@ export const HeroSection = () => {
                 onClick={() => handleNavigation('/downloads', false)}
                 className="h-12 px-8 border-slate-600 hover:border-slate-500 text-slate-300 hover:text-gray-200 flex sm:hidden items-center justify-center gap-2 w-full"
               >
-                <Monitor className="w-5 h-5" />
-                {t('Test Desktop App')}
+                <Download className="w-5 h-5" />
+                {t('Download the Apps')}
               </Button>
               <Button
                 variant="outline"
@@ -85,7 +85,7 @@ export const HeroSection = () => {
                 className="h-12 px-8 border-slate-600 hover:border-slate-500 text-slate-300 hover:text-gray-200 hidden sm:flex items-center gap-2"
               >
                 <Download className="w-5 h-5" />
-                {t('Download Desktop')}
+                {t('Download the Apps')}
               </Button>
             </div>
           </AnimateIn>

--- a/src/constants/navigation.ts
+++ b/src/constants/navigation.ts
@@ -3,8 +3,8 @@ import { PRODUCTS, GITHUB, SOCIALS } from '@/constants/urls'
 
 export const productItems = [
   {
-    label: 'Browser Extension',
-    href: '/products/extension',
+    label: 'KaleidoSDK',
+    href: '/products/sdk',
     external: false,
     status: 'live' as const,
   },
@@ -15,14 +15,14 @@ export const productItems = [
     status: 'live' as const,
   },
   {
-    label: 'KaleidoSDK',
-    href: '/products/sdk',
+    label: 'Browser Extension',
+    href: '/products/extension',
     external: false,
     status: 'live' as const,
   },
   {
     label: 'Web App',
-    href: '/products/web-app',
+    href: '#',
     external: false,
     status: 'coming-soon' as const,
   },

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -143,11 +143,10 @@ export const Products = () => {
             {products.map((product) => {
               const Icon = product.icon
               const isLive = product.status === 'live'
-              const isTestnetSoon = product.status === 'testnet-soon'
               const hasPage = product.href !== '#'
               const cc = colorConfig[product.color] ?? colorConfig.gray
-              const chipClass = isLive ? cc.chip : isTestnetSoon ? 'bg-amber-500/20 text-amber-400' : cc.chip
-              const chipText = product.chipLabel ?? (isLive ? 'Live' : isTestnetSoon ? 'Testnet Soon' : 'Coming Soon')
+              const chipClass = cc.chip
+              const chipText = product.chipLabel ?? (isLive ? 'Live' : 'Coming Soon')
 
               return (
                 <div

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -8,40 +8,37 @@ import { footerConfig } from '@/constants/footer'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 
+const colorConfig: Record<string, { icon: string; title: string; border: string; chip: string; check: string }> = {
+  purple: {
+    icon: 'bg-purple-500/10 text-purple-400',
+    title: 'text-purple-400',
+    border: 'hover:border-purple-500/30',
+    chip: 'bg-purple-500/20 text-purple-400',
+    check: 'text-purple-400',
+  },
+  green: {
+    icon: 'bg-green-500/10 text-green-400',
+    title: 'text-green-400',
+    border: 'hover:border-green-500/30',
+    chip: 'bg-green-500/20 text-green-400',
+    check: 'text-green-400',
+  },
+  gray: {
+    icon: 'bg-gray-700/50 text-gray-500',
+    title: 'text-gray-500',
+    border: '',
+    chip: 'bg-gray-700 text-gray-400',
+    check: 'text-gray-600',
+  },
+}
+
 const products = [
-  {
-    id: 'web-app',
-    name: 'Web App',
-    icon: Globe,
-    status: 'testnet-soon' as const,
-    description: 'The fastest way to swap. No download required. Launching on testnet soon — app.kaleidoswap.com will be your gateway to RGB swaps directly in the browser.',
-    features: [
-      'No installation required',
-      'Works on any browser',
-      'Real-time quotes',
-    ],
-    href: '/products/web-app',
-    color: 'primary',
-  },
-  {
-    id: 'desktop',
-    name: 'Desktop App',
-    icon: Monitor,
-    status: 'live' as const,
-    description: 'Full sovereignty. Bundles a complete RGB Lightning node. Your infrastructure, your rules.',
-    features: [
-      'Integrated RGB-LN node',
-      'macOS, Windows, Linux',
-      'Maximum privacy',
-    ],
-    href: '/products/desktop',
-    color: 'secondary',
-  },
   {
     id: 'sdk',
     name: 'Developer SDK',
     icon: Code,
     status: 'live' as const,
+    chipLabel: 'Ready to Integrate',
     description: 'Build on KaleidoSwap. TypeScript and Rust SDKs with full documentation.',
     features: [
       'Full API documentation',
@@ -49,13 +46,29 @@ const products = [
       'Market maker tools',
     ],
     href: '/products/sdk',
+    color: 'purple',
+  },
+  {
+    id: 'desktop',
+    name: 'Desktop App',
+    icon: Monitor,
+    status: 'live' as const,
+    chipLabel: 'Live on Testnet',
+    description: 'Full sovereignty. Bundles a complete RGB Lightning node. Your infrastructure, your rules.',
+    features: [
+      'Integrated RGB-LN node',
+      'macOS, Windows, Linux',
+      'Maximum privacy',
+    ],
+    href: '/products/desktop',
     color: 'green',
   },
   {
     id: 'extension',
-    name: 'KaleidoSwap Extension',
+    name: 'Browser Extension',
     icon: Puzzle,
-    status: 'coming-soon' as const,
+    status: 'live' as const,
+    chipLabel: 'Live on Mainnet',
     description: 'Multi-protocol Chrome extension wallet. Bitcoin, Lightning, RGB, and more from your toolbar.',
     features: [
       'Multi-protocol wallet',
@@ -63,11 +76,25 @@ const products = [
       'DApp connectivity',
     ],
     href: '/products/extension',
-    color: 'purple',
+    color: 'green',
+  },
+  {
+    id: 'web-app',
+    name: 'Web App',
+    icon: Globe,
+    status: 'coming-soon' as const,
+    description: 'The fastest way to swap. No download required. Launching on testnet soon.',
+    features: [
+      'No installation required',
+      'Works on any browser',
+      'Real-time quotes',
+    ],
+    href: '#',
+    color: 'gray',
   },
   {
     id: 'mobile',
-    name: 'Rate (Mobile)',
+    name: 'Mobile App',
     icon: Smartphone,
     status: 'coming-soon' as const,
     description: 'Swap on the go. Native iOS and Android apps with the same security.',
@@ -117,55 +144,32 @@ export const Products = () => {
               const Icon = product.icon
               const isLive = product.status === 'live'
               const isTestnetSoon = product.status === 'testnet-soon'
-
               const hasPage = product.href !== '#'
+              const cc = colorConfig[product.color] ?? colorConfig.gray
+              const chipClass = isLive ? cc.chip : isTestnetSoon ? 'bg-amber-500/20 text-amber-400' : cc.chip
+              const chipText = product.chipLabel ?? (isLive ? 'Live' : isTestnetSoon ? 'Testnet Soon' : 'Coming Soon')
 
               return (
                 <div
                   key={product.id}
-                  className={`glass-card rounded-2xl p-8 transition-all ${
+                  className={`relative glass-card rounded-2xl p-8 transition-all ${
                     hasPage
-                      ? 'cursor-pointer hover:border-primary-500/30'
+                      ? `cursor-pointer ${cc.border}`
                       : 'opacity-60'
                   }`}
                   onClick={() => hasPage && navigate(product.href)}
                 >
-                  <div className="flex flex-col md:flex-row md:items-center gap-6">
+                  <div className="flex flex-col md:flex-row md:items-stretch gap-6">
                     {/* Icon */}
-                    <div
-                      className={`p-4 rounded-xl shrink-0 w-fit ${
-                        product.color === 'primary'
-                          ? 'bg-primary-500/10 text-primary-400'
-                          : product.color === 'secondary'
-                          ? 'bg-secondary-500/10 text-secondary-400'
-                          : product.color === 'green'
-                          ? 'bg-green-500/10 text-green-400'
-                          : product.color === 'purple'
-                          ? 'bg-purple-500/10 text-purple-400'
-                          : 'bg-gray-700/50 text-gray-500'
-                      }`}
-                    >
+                    <div className={`p-4 rounded-xl shrink-0 w-fit self-start ${cc.icon}`}>
                       <Icon className="w-8 h-8" />
                     </div>
 
                     {/* Content */}
                     <div className="flex-1">
-                      <div className="flex items-center gap-3 mb-2">
-                        <h2 className="text-2xl font-bold">
-                          {t(product.name)}
-                        </h2>
-                        <span
-                          className={`text-xs font-medium px-2 py-1 rounded-full ${
-                            isLive
-                              ? 'bg-green-500/20 text-green-400'
-                              : isTestnetSoon
-                              ? 'bg-amber-500/20 text-amber-400'
-                              : 'bg-gray-700 text-gray-400'
-                          }`}
-                        >
-                          {isLive ? t('Live') : isTestnetSoon ? t('Testnet Soon') : t('Coming Soon')}
-                        </span>
-                      </div>
+                      <h2 className={`text-2xl font-bold mb-2 ${cc.title}`}>
+                        {t(product.name)}
+                      </h2>
 
                       <p className="text-slate-400 mb-4">
                         {t(product.description)}
@@ -177,29 +181,33 @@ export const Products = () => {
                             key={i}
                             className="flex items-center gap-2 text-sm text-slate-300"
                           >
-                            <Check
-                              className={`w-4 h-4 ${
-                                hasPage ? 'text-primary-500' : 'text-gray-600'
-                              }`}
-                            />
+                            <Check className={`w-4 h-4 ${cc.check}`} />
                             {t(feature)}
                           </div>
                         ))}
                       </div>
                     </div>
 
-                    {/* Arrow */}
-                    {hasPage && (
-                      <div className="shrink-0">
+                    {/* Chip — mobile only, absolute top-right */}
+                    <span className={`md:hidden absolute top-4 right-4 text-xs font-medium px-2 py-1 rounded-full whitespace-nowrap ${chipClass}`}>
+                      {t(chipText)}
+                    </span>
+
+                    {/* Right column: chip + button */}
+                    <div className="shrink-0 flex flex-col items-start md:items-end justify-between gap-3">
+                      <span className={`invisible md:visible text-xs font-medium px-2 py-1 rounded-full whitespace-nowrap ${chipClass}`}>
+                        {t(chipText)}
+                      </span>
+                      {hasPage && (
                         <Button
                           variant="outline"
-                          className="border-slate-700 hover:border-primary-500"
+                          className="border-slate-600 hover:border-slate-500 text-slate-300 hover:text-gray-200"
                         >
                           {t('Learn More')}
                           <ArrowRight className="w-4 h-4 ml-2" />
                         </Button>
-                      </div>
-                    )}
+                      )}
+                    </div>
                   </div>
                 </div>
               )


### PR DESCRIPTION
Products page:
- Reorder cards: SDK first, then Desktop, Browser Extension, Web App (coming soon), Mobile App (coming soon)
- Rename 'KaleidoSwap Extension' → 'Browser Extension', 'Rate (Mobile)' → 'Mobile App'; keep Web App as a separate coming-soon card
- Colours: SDK → purple, Desktop & Extension → green, coming-soon cards → gray
- Per-product chip labels: 'Ready to Integrate' (SDK), 'Live on Testnet' (Desktop), 'Live on Mainnet' (Extension); chip colour matches product colour
- Layout: chip absolute top-right on mobile (in-flow on desktop), Learn More button bottom-right on desktop; button left-aligned on mobile
- Icon backgrounds restored to square (self-start on flex-stretch container)
- Learn More hover matches Hero outline button style (border-slate-600 → slate-500, text-slate-300 → gray-200)

Navigation:
- productItems reordered to match page (SDK first); Web App entry removed (now coming-soon only in page)

Hero (HeroSection):
- Primary CTA now links to /products/sdk (internal)
- Secondary CTA renamed 'Download the Apps' on both mobile and desktop; icon unified to Download