### PR TITLE
fix: reorder Products cards

### DIFF
--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -72,7 +72,7 @@ export const HeroSection = () => {
               <Button
                 variant="outline"
                 size="lg"
-                onClick={() => handleNavigation('/downloads', false)}
+                onClick={() => handleNavigation('https://kaleidoswap.com/products', true)}
                 className="h-12 px-8 border-slate-600 hover:border-slate-500 text-slate-300 hover:text-gray-200 flex sm:hidden items-center justify-center gap-2 w-full"
               >
                 <Download className="w-5 h-5" />
@@ -81,7 +81,7 @@ export const HeroSection = () => {
               <Button
                 variant="outline"
                 size="lg"
-                onClick={() => handleNavigation('/downloads', false)}
+                onClick={() => handleNavigation('https://kaleidoswap.com/products', true)}
                 className="h-12 px-8 border-slate-600 hover:border-slate-500 text-slate-300 hover:text-gray-200 hidden sm:flex items-center gap-2"
               >
                 <Download className="w-5 h-5" />

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -49,21 +49,6 @@ const products = [
     color: 'purple',
   },
   {
-    id: 'desktop',
-    name: 'Desktop App',
-    icon: Monitor,
-    status: 'live' as const,
-    chipLabel: 'Live on Testnet',
-    description: 'Full sovereignty. Bundles a complete RGB Lightning node. Your infrastructure, your rules.',
-    features: [
-      'Integrated RGB-LN node',
-      'macOS, Windows, Linux',
-      'Maximum privacy',
-    ],
-    href: '/products/desktop',
-    color: 'green',
-  },
-  {
     id: 'extension',
     name: 'Browser Extension',
     icon: Puzzle,
@@ -76,6 +61,21 @@ const products = [
       'DApp connectivity',
     ],
     href: '/products/extension',
+    color: 'green',
+  },
+  {
+    id: 'desktop',
+    name: 'Desktop App',
+    icon: Monitor,
+    status: 'live' as const,
+    chipLabel: 'Live on Testnet',
+    description: 'Full sovereignty. Bundles a complete RGB Lightning node. Your infrastructure, your rules.',
+    features: [
+      'Integrated RGB-LN node',
+      'macOS, Windows, Linux',
+      'Maximum privacy',
+    ],
+    href: '/products/desktop',
     color: 'green',
   },
   {


### PR DESCRIPTION
Move Browser Extension above Desktop App in the Products page grid (order: SDK → Extension → Desktop → Web App → Mobile)